### PR TITLE
ADM remediating 1 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
    <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.1</version>
       </dependency>
 
   </dependencies>


### PR DESCRIPTION
Vulnerabilities:
* CVE-2021-44832: org.apache.logging.log4j:log4j-core:2.17.0

Dependencies upgraded:
* org.apache.logging.log4j:log4j-core:2.17.0 -> 2.17.1

Auto-merge is disabled